### PR TITLE
Upgrading Scala Version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         </developer>
     </developers>
     <properties>
-        <scala.version>2.10.0</scala.version>
+        <scala.version>2.11.6</scala.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>scala*;version="[2.10,2.11)",*</Import-Package>
+                        <Import-Package>scala*;version="[2.11,2.12)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Hello Benjamin, 

we are using you domino library within our OSGi project, which otherwise uses Scala 2.11. I noticed some tests were failing in our own bundles when relying on Domino 1.0.0 which relies on Scala 2.10. 

I have updated the pom and recompiled domino and everything worked fine. Perhaps you want to consider accepting the pull request. 

Best regards
Andreas
