### PR TITLE
Removed unused log statement in ServiceWatching trait.

### DIFF
--- a/src/main/scala/domino/logging/internal/DominoLogger.scala
+++ b/src/main/scala/domino/logging/internal/DominoLogger.scala
@@ -4,7 +4,7 @@ import scala.reflect.ClassTag
 import scala.reflect.classTag
 
 /**
- * Experimental logger facade, meant for internal user in Domino OSGi.
+ * Experimental logger facade, meant for internal use in Domino OSGi.
  */
 trait DominoLogger extends Serializable {
   def isErrorEnabled: Boolean

--- a/src/main/scala/domino/service_watching/ServiceWatching.scala
+++ b/src/main/scala/domino/service_watching/ServiceWatching.scala
@@ -19,8 +19,6 @@ import org.osgi.util.tracker.ServiceTracker
  */
 trait ServiceWatching extends DominoImplicits {
 
-  private[this] lazy val log = DominoLogger[this.type]
-
   /** Dependency */
   protected def capsuleContext: CapsuleContext
 


### PR DESCRIPTION
The statement 
```
private[this] lazy val log = DominoLogger[this.type]
```
in trait `ServiceWatching` causes an unwanted import in bundles using the `ServiceWatching` trait. If logging is required in traits we have to find another solution or use types within the public API only. 

Also fixed a minor DominoLogger. 
